### PR TITLE
Bump package versions

### DIFF
--- a/Gameplay.PlayableNodes.Core/package.json
+++ b/Gameplay.PlayableNodes.Core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.avmedvedskiy.playblenodes.core",
   "displayName": "Gameplay.PlayableNodes.Core",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "unity": "2022.3",
   "author": "avmedvedskiy",
   "description": "Playable Node Core",

--- a/Gameplay.PlayableNodes.Tween/Runtime/Animation/SetBoolAnimator.cs
+++ b/Gameplay.PlayableNodes.Tween/Runtime/Animation/SetBoolAnimator.cs
@@ -1,0 +1,22 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+
+namespace PlayableNodes.Animations
+{
+    [Serializable]
+    [Description("Sets a bool parameter in an Animator")]
+    public class SetBoolAnimator : TargetAnimation<Animator>
+    {
+        [SerializeField] private string _parameterName;
+        [SerializeField] private bool _value;
+
+        protected override async UniTask Play(CancellationToken cancellationToken)
+        {
+            Target.SetBool(_parameterName, _value);
+            await UniTask.WaitForSeconds(Duration, cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/Gameplay.PlayableNodes.Tween/Runtime/Animation/SetBoolAnimator.cs.meta
+++ b/Gameplay.PlayableNodes.Tween/Runtime/Animation/SetBoolAnimator.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b903a426c9be4cc4b68f4514e1bba75c
+timeCreated: 1751619324

--- a/Gameplay.PlayableNodes.Tween/package.json
+++ b/Gameplay.PlayableNodes.Tween/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.avmedvedskiy.playblenodes.tween",
   "displayName": "Gameplay.PlayableNodes.Tween",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "unity": "2022.3",
   "author": "avmedvedskiy",
   "description": "Playable Node Tween",


### PR DESCRIPTION
## Summary
- make SetBoolAnimator async
- bump versions for Core and Tween packages

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6867967f85588331bffe7e61c0e323b2