### PR TITLE
Add curve-based MeshRenderer material tween

### DIFF
--- a/Gameplay.PlayableNodes.Tween/Runtime/Renderers/AnimateMeshRendererMaterialFloatCurve.cs
+++ b/Gameplay.PlayableNodes.Tween/Runtime/Renderers/AnimateMeshRendererMaterialFloatCurve.cs
@@ -1,0 +1,52 @@
+using System;
+using System.ComponentModel;
+using DG.Tweening;
+using PlayableNodes.Animations;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace PlayableNodes
+{
+    [Serializable]
+    [Description("Tweens a float material property on a MeshRenderer using an AnimationCurve and optionally restores the original material on completion")]
+    public class AnimateMeshRendererMaterialFloatCurve : TweenAnimation<MeshRenderer>
+    {
+        [SerializeField] private Material _material;
+        [SerializeField] private AnimationCurve _curve = AnimationCurve.Linear(0f, 0f, 1f, 1f);
+        [SerializeField] private string _fieldName;
+        [SerializeField] private bool _resetMaterialOnComplete = true;
+
+        private Material _lastMaterial;
+
+        protected override Tween GenerateTween()
+        {
+            float t = 0f;
+            return DOTween
+                .To(() => t, x => Set(_curve.Evaluate(x)), 1f, Duration)
+                .OnStart(OnStart)
+                .OnComplete(OnComplete);
+        }
+
+        private void OnStart()
+        {
+            _lastMaterial = Target.sharedMaterial;
+            var baseMaterial = _material == null ? _lastMaterial : _material;
+            Target.material = Object.Instantiate(baseMaterial);
+            Set(_curve.Evaluate(0f));
+        }
+
+        private void OnComplete()
+        {
+            if (Target && _resetMaterialOnComplete)
+            {
+                Target.material.DestroyOrPreview();
+                Target.material = _lastMaterial;
+            }
+        }
+
+        private void Set(float value)
+        {
+            Target.material.SetFloat(_fieldName, value);
+        }
+    }
+}

--- a/Gameplay.PlayableNodes.Tween/Runtime/Renderers/AnimateMeshRendererMaterialFloatCurve.cs.meta
+++ b/Gameplay.PlayableNodes.Tween/Runtime/Renderers/AnimateMeshRendererMaterialFloatCurve.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0790c595589945d39dbdd43109369a71
+timeCreated: 1750842950

--- a/Gameplay.PlayableNodes.Tween/Runtime/Renderers/AnimateMeshRendererMaterialFloatVariable.cs
+++ b/Gameplay.PlayableNodes.Tween/Runtime/Renderers/AnimateMeshRendererMaterialFloatVariable.cs
@@ -1,0 +1,53 @@
+using System;
+using System.ComponentModel;
+using DG.Tweening;
+using PlayableNodes.Animations;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace PlayableNodes
+{
+    [Serializable]
+    [Description("Tweens a float property on a MeshRenderer material and optionally restores the original material on completion")]
+    public class AnimateMeshRendererMaterialFloatVariable : TweenAnimation<MeshRenderer>
+    {
+        [SerializeField] private Material _material;
+        [SerializeField] private float _from;
+        [SerializeField] private float _to;
+        [SerializeField] private string _fieldName;
+        [SerializeField] private bool _resetMaterialOnComplete = true;
+
+        private Material _lastMaterial;
+
+        protected override Tween GenerateTween()
+        {
+            return DOTween
+                .To(() => _from, Set, _to, Duration)
+                .OnStart(OnStart)
+                .OnComplete(OnComplete)
+                .ChangeStartValue(_from);
+        }
+
+        private void OnStart()
+        {
+            _lastMaterial = Target.sharedMaterial;
+            var baseMaterial = _material == null ? _lastMaterial : _material;
+            Target.material = Object.Instantiate(baseMaterial);
+            Set(_from);
+        }
+
+        private void OnComplete()
+        {
+            if (Target && _resetMaterialOnComplete)
+            {
+                Target.material.DestroyOrPreview();
+                Target.material = _lastMaterial;
+            }
+        }
+
+        private void Set(float value)
+        {
+            Target.material.SetFloat(_fieldName, value);
+        }
+    }
+}

--- a/Gameplay.PlayableNodes.Tween/Runtime/Renderers/AnimateMeshRendererMaterialFloatVariable.cs.meta
+++ b/Gameplay.PlayableNodes.Tween/Runtime/Renderers/AnimateMeshRendererMaterialFloatVariable.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: bd75bd9d14cb49c8bb2a58cee61c4d9f
+timeCreated: 1750842948


### PR DESCRIPTION
## Summary
- implement `AnimateMeshRendererMaterialFloatCurve` to tween a material float using an AnimationCurve
- implement `AnimateMeshRendererMaterialFloatVariable` to tween a float property on a material
- allow both nodes to use the target's current material when none is provided

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_685bbd1eb0c08331b47f560658cc976f